### PR TITLE
added support for vscode jest debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Jest Tests",
+        "type": "node",
+        "request": "launch",
+        "runtimeArgs": [
+          "--inspect-brk",
+          "${workspaceRoot}/node_modules/.bin/jest",
+          "--runInBand"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "port": 9229
+      }
+    ]
+}


### PR DESCRIPTION
added jest vscode launch configuration to allow attaching vscode debugger to jest runners. To activate, to `Run and Debug` section of vscode start `Debug Jest Test` config, the test routines will intercept on whichever breakpoint it passes through.

<img width="1440" alt="Screenshot 2021-09-25 at 1 32 10 PM" src="https://user-images.githubusercontent.com/6298342/134765173-5e353f23-f51c-451a-8af4-10f7dcaf9ed5.png">
