### PR TITLE
WIP - Nt/entity encryption

### DIFF
--- a/lib/post-body-summary.d.ts
+++ b/lib/post-body-summary.d.ts
@@ -1,2 +1,2 @@
 import { Entry } from './types';
-export declare function getPostBodySummary(obj: Entry | string, length?: number): any;
+export declare function getPostBodySummary(obj: Entry | string, length?: number, platform?:'ios'|'android'|'web'): any;

--- a/lib/post-body-summary.js
+++ b/lib/post-body-summary.js
@@ -36,7 +36,7 @@ var joint = function (arr, limit) {
     }
     return result.trim();
 };
-function postBodySummary(entryBody, length) {
+function postBodySummary(entryBody, length, platform) {
     if (!entryBody) {
         return '';
     }
@@ -65,7 +65,7 @@ function postBodySummary(entryBody, length) {
 
   //encrypt entities
   const entities = entryBody.match(/&(.*?);/g);
-  const encEntities:string[] = [];
+  const encEntities = [];
   if(entities && platform !== 'web'){
     entities.forEach((entity)=>{
       var CryptoJS = require("react-native-crypto-js");
@@ -112,16 +112,16 @@ function postBodySummary(entryBody, length) {
     }
     return text;
 }
-function getPostBodySummary(obj, length) {
+function getPostBodySummary(obj, length, platform) {
     if (typeof obj === 'string') {
-        return postBodySummary(obj, length);
+        return postBodySummary(obj, length, platform);
     }
     var key = helper_1.makeEntryCacheKey(obj) + "-sum-" + length;
     var item = cache_1.cacheGet(key);
     if (item) {
         return item;
     }
-    var res = postBodySummary(obj.body, length);
+    var res = postBodySummary(obj.body, length, platform);
     cache_1.cacheSet(key, res);
     return res;
 }

--- a/lib/post-body-summary.js
+++ b/lib/post-body-summary.js
@@ -60,6 +60,23 @@ function postBodySummary(entryBody, length) {
         'sub',
         'sup'
     ]);
+
+
+
+  //encrypt entities
+  const entities = entryBody.match(/&(.*?);/g);
+  const encEntities:string[] = [];
+  if(entities && platform !== 'web'){
+    entities.forEach((entity)=>{
+      var CryptoJS = require("react-native-crypto-js");
+      const encData = CryptoJS.AES.encrypt(entity, 'key').toString();
+      let encyptedEntity = CryptoJS.enc.Base64.stringify(CryptoJS.enc.Utf8.parse(encData));
+      encEntities.push(encyptedEntity);
+      entryBody = entryBody.replace(entity, encyptedEntity);
+    })
+  }
+
+
     // Convert markdown to html
     var text = '';
     try {
@@ -68,6 +85,18 @@ function postBodySummary(entryBody, length) {
     catch (err) {
         console.log(err);
     }
+
+
+      //decrypt and put back entiteis
+  if(platform !== 'web'){
+    encEntities.forEach((encEntity)=>{
+      var CryptoJS = require("react-native-crypto-js");
+      let decData = CryptoJS.enc.Base64.parse(encEntity).toString(CryptoJS.enc.Utf8);
+      let entity = CryptoJS.AES.decrypt(decData, 'key').toString(CryptoJS.enc.Utf8);
+      text = text.replace(encEntity, entity);
+    })
+  }
+
     text = text
         .replace(/(<([^>]+)>)/gi, '') // Remove html tags
         .replace(/\r?\n|\r/g, ' ') // Remove new lines

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "multihashes": "0.4.13",
     "path": "^0.12.7",
     "querystring": "^0.2.0",
+    "react-native-crypto-js": "^1.0.0",
     "remarkable": "^2.0.1",
     "url": "^0.11.0",
     "xmldom": "^0.5.0",

--- a/src/post-body-summary.spec.ts
+++ b/src/post-body-summary.spec.ts
@@ -140,4 +140,11 @@ So, how can you qualify to get one?`
     const expected = 'Lorem Ipsum Dolor'
     expect(getPostBodySummary(input)).toBe(expected)
   })
+
+
+  it('12- Test entity parsing', () => {
+    const input = 'http://lorem.com Lorem &lt; Ipsum &amp; Dolor &euro;	'
+    const expected = 'Lorem < Ipsum & Dolor €'
+    expect(getPostBodySummary(input)).toBe(expected)
+  })
 })


### PR DESCRIPTION
The code is experimental and not very clean. I am using react-native-crypto to hide entities and put them back after remarkable is done processing.

Please review once so I can work on organising code better and extend it to other methods like `markdownToHtml`, right now it's only working for `getPostBodySummary`

Also comment on why there are 2 variants and `ts` and other `js` for each method, while doing jest `ts` versions are using while once imported in app, `js` versions of methods are used.

![Screenshot 2021-10-12 at 4 33 10 PM](https://user-images.githubusercontent.com/6298342/136948904-0aeb994d-8f74-4b87-acae-be1bbe09686d.png)
