### PR TITLE
allow youtube id in markdown-video-link-youtube

### DIFF
--- a/lib/consts/allowed-attributes.const.js
+++ b/lib/consts/allowed-attributes.const.js
@@ -13,6 +13,7 @@ exports.ALLOWED_ATTRIBUTES = {
         'data-community',
         'data-filter',
         'data-embed-src',
+        'data-youtube',
         'data-video-href',
         'data-proposal',
         'class',

--- a/lib/methods/a.method.js
+++ b/lib/methods/a.method.js
@@ -338,6 +338,7 @@ function a(el, forApp, webp) {
             var embedSrc = "https://www.youtube.com/embed/" + vid + "?autoplay=1";
             el.textContent = '';
             el.setAttribute('data-embed-src', embedSrc);
+            el.setAttribute('data-youtube', vid);
             var thumbImg = el.ownerDocument.createElement('img');
             thumbImg.setAttribute('class', 'no-replace video-thumbnail');
             thumbImg.setAttribute('itemprop', 'thumbnailUrl');

--- a/lib/methods/text.method.js
+++ b/lib/methods/text.method.js
@@ -27,7 +27,7 @@ function text(node, forApp, webp) {
             var vid = e[1];
             var thumbnail = proxify_image_src_1.proxifyImageSrc("https://img.youtube.com/vi/" + vid.split('?')[0] + "/hqdefault.jpg", 0, 0, webp ? 'webp' : 'match');
             var embedSrc = "https://www.youtube.com/embed/" + vid + "?autoplay=1";
-            var attrs = "class=\"markdown-video-link markdown-video-link-youtube\" data-embed-src=\"" + embedSrc + "\"";
+            var attrs = "class=\"markdown-video-link markdown-video-link-youtube\" data-embed-src=\"" + embedSrc + "\" data-youtube=\"" + vid + "\"";
             var thumbImg = node.ownerDocument.createElement('img');
             thumbImg.setAttribute('class', 'no-replace video-thumbnail');
             thumbImg.setAttribute('src', thumbnail);

--- a/src/consts/allowed-attributes.const.ts
+++ b/src/consts/allowed-attributes.const.ts
@@ -12,6 +12,7 @@ export const ALLOWED_ATTRIBUTES: XSSWhiteList = {
     'data-community',
     'data-filter',
     'data-embed-src',
+    'data-youtube',
     'data-video-href',
     'data-proposal',
     'class',

--- a/src/markdown-2-html.spec.ts
+++ b/src/markdown-2-html.spec.ts
@@ -70,7 +70,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'https://www.youtube.com/watch?v=qK3d1eoH-Qs'
       }
-      const expected = '<p><a class="markdown-video-link markdown-video-link-youtube" data-embed-src="https://www.youtube.com/embed/qK3d1eoH-Qs?autoplay=1"><img class="no-replace video-thumbnail" src="https://images.ecency.com/p/S5Eokt4BcQdk7EHeT1aYjzebg2hC7hkthT45eMZRVYW6mkGBWKemLWWzXbRhNG7Z3h1qjGS.png?format=match&amp;mode=fit" /><span class="markdown-video-play"></span></a></p>'
+      const expected = '<p><a class="markdown-video-link markdown-video-link-youtube" data-embed-src="https://www.youtube.com/embed/qK3d1eoH-Qs?autoplay=1" data-youtube="qK3d1eoH-Qs"><img class="no-replace video-thumbnail" src="https://images.ecency.com/p/S5Eokt4BcQdk7EHeT1aYjzebg2hC7hkthT45eMZRVYW6mkGBWKemLWWzXbRhNG7Z3h1qjGS.png?format=match&amp;mode=fit" /><span class="markdown-video-play"></span></a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -447,7 +447,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'https://youtu.be/_-6hJ8sltdI'
       }
-      const expected = '<p><a class="markdown-video-link markdown-video-link-youtube" data-embed-src="https://www.youtube.com/embed/_-6hJ8sltdI?autoplay=1"><img class="no-replace video-thumbnail" src="https://images.ecency.com/p/S5Eokt4BcQdk7EHeT1aYjzebg2hC7hkthT45eEGc5AMBA14JMjkkxrUAj3mV5QR9D6zfstr.png?format=match&amp;mode=fit" /><span class="markdown-video-play"></span></a></p>'
+      const expected = '<p><a class="markdown-video-link markdown-video-link-youtube" data-embed-src="https://www.youtube.com/embed/_-6hJ8sltdI?autoplay=1" data-youtube="_-6hJ8sltdI"><img class="no-replace video-thumbnail" src="https://images.ecency.com/p/S5Eokt4BcQdk7EHeT1aYjzebg2hC7hkthT45eEGc5AMBA14JMjkkxrUAj3mV5QR9D6zfstr.png?format=match&amp;mode=fit" /><span class="markdown-video-play"></span></a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })

--- a/src/methods/a.method.ts
+++ b/src/methods/a.method.ts
@@ -412,8 +412,9 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
       const embedSrc = `https://www.youtube.com/embed/${vid}?autoplay=1`
 
       el.textContent = ''
-
-      el.setAttribute('data-embed-src', embedSrc)
+     
+      el.setAttribute('data-embed-src', embedSrc);
+      el.setAttribute('data-youtube', vid);
 
       const thumbImg = el.ownerDocument.createElement('img')
       thumbImg.setAttribute('class', 'no-replace video-thumbnail')

--- a/src/methods/text.method.ts
+++ b/src/methods/text.method.ts
@@ -34,7 +34,7 @@ export function text(node: HTMLElement, forApp: boolean, webp: boolean): void {
       const thumbnail = proxifyImageSrc(`https://img.youtube.com/vi/${vid.split('?')[0]}/hqdefault.jpg`, 0, 0, webp ? 'webp' : 'match')
       const embedSrc = `https://www.youtube.com/embed/${vid}?autoplay=1`
 
-      const attrs = `class="markdown-video-link markdown-video-link-youtube" data-embed-src="${embedSrc}"`
+      const attrs = `class="markdown-video-link markdown-video-link-youtube" data-embed-src="${embedSrc}" data-youtube="${vid}"`
 
       const thumbImg = node.ownerDocument.createElement('img')
       thumbImg.setAttribute('class', 'no-replace video-thumbnail')


### PR DESCRIPTION
Right now I post process youtube link to extract video id from that, yet it seems render helper already process the youtube link however it was not passing the youtube id down with tag. Now it does as `data-youtube`

On app side, I can simply use that id plug-n-play with video player modal