### PR TITLE
processing thumbnail less dtube link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecency/render-helper",
-  "version": "2.2.14",
+  "version": "2.2.15",
   "description": "Markdown+Html Render helper",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/markdown-2-html.spec.ts
+++ b/src/markdown-2-html.spec.ts
@@ -99,6 +99,30 @@ describe('Markdown2Html', () => {
       expect(markdown2Html(input)).toBe(expected)
     })
 
+    it('7.1- Should handle raw d.tube videos without thumbnail', () => {
+      const input = {
+        author: 'foo37.1',
+        permlink: 'bar37.1',
+        last_update: '2020-05-10T09:15:21',
+        body: 'https://d.tube/#!/v/techcoderx/QmVdEYicJwiTxSk2U9ER1Yc8Rumb1Nek4KynqAYGyQs7ga'
+      }
+      const expected = '<p><a class="markdown-video-link markdown-video-link-dtube" data-embed-src="https://emb.d.tube/#!/techcoderx/QmVdEYicJwiTxSk2U9ER1Yc8Rumb1Nek4KynqAYGyQs7ga"><span class="markdown-video-play"></span></a></p>'
+
+      expect(markdown2Html(input)).toBe(expected)
+    })
+
+    it('7.2- Should handle raw d.tube videos different format', () => {
+      const input = {
+        author: 'foo37.2',
+        permlink: 'bar37.2',
+        last_update: '2020-05-10T09:15:21',
+        body: 'https://d.tube/v/techcoderx/QmVdEYicJwiTxSk2U9ER1Yc8Rumb1Nek4KynqAYGyQs7ga'
+      }
+      const expected = '<p><a class="markdown-video-link markdown-video-link-dtube" data-embed-src="https://emb.d.tube/#!/techcoderx/QmVdEYicJwiTxSk2U9ER1Yc8Rumb1Nek4KynqAYGyQs7ga"><span class="markdown-video-play"></span></a></p>'
+
+      expect(markdown2Html(input)).toBe(expected)
+    })
+
     it('9- Should handle witnesses links', () => {
       const input = {
         author: 'foo39',

--- a/src/methods/a.method.ts
+++ b/src/methods/a.method.ts
@@ -539,36 +539,45 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
   // If a d.tube video
   match = href.match(D_TUBE_REGEX)
   if (match) {
-    // Only d.tube links contains an image
-    const imgEls = el.getElementsByTagName('img')
 
-    if (imgEls.length === 1) {
+     // Only d.tube links contains an image
+     const imgEls = el.getElementsByTagName('img')
+
+     if (imgEls.length === 1 || el.textContent.trim() === href) {
       const e = D_TUBE_REGEX.exec(href)
       // e[2] = username, e[3] object id
       if (e[2] && e[3]) {
         el.setAttribute('class', 'markdown-video-link markdown-video-link-dtube')
         el.removeAttribute('href')
+   
 
-        const thumbnail = proxifyImageSrc(imgEls[0].getAttribute('src').replace(/\s+/g, ''), 0, 0, webp ? 'webp' : 'match')
         const videoHref = `https://emb.d.tube/#!/${e[2]}/${e[3]}`
 
         // el.setAttribute('data-video-href', videoHref)
         el.setAttribute('data-embed-src', videoHref)
 
-        const thumbImg = el.ownerDocument.createElement('img')
-        thumbImg.setAttribute('class', 'no-replace video-thumbnail')
-        thumbImg.setAttribute('itemprop', 'thumbnailUrl')
-        
-        thumbImg.setAttribute('src', thumbnail)
+        //process thumb img element 
+        if (imgEls.length === 1) {
+          const thumbnail = proxifyImageSrc(imgEls[0].getAttribute('src').replace(/\s+/g, ''), 0, 0, webp ? 'webp' : 'match') 
+          const thumbImg = el.ownerDocument.createElement('img')
+
+          thumbImg.setAttribute('class', 'no-replace video-thumbnail')
+          thumbImg.setAttribute('itemprop', 'thumbnailUrl')
+            
+          thumbImg.setAttribute('src', thumbnail)
+          el.appendChild(thumbImg)
+
+          // Remove image.
+          el.removeChild(imgEls[0])
+        } else {
+            el.textContent = '';
+        }
 
         const play = el.ownerDocument.createElement('span')
         play.setAttribute('class', 'markdown-video-play')
 
-        el.appendChild(thumbImg)
+  
         el.appendChild(play)
-
-        // Remove image.
-        el.removeChild(imgEls[0])
 
         return
       }
@@ -581,6 +590,7 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
     if (e[2] && e[3]) {
       el.setAttribute('class', 'markdown-video-link markdown-video-link-dtube')
       el.removeAttribute('href')
+      el.textContent = '';
 
       const videoHref = `https://emb.d.tube/#!/${e[2]}/${e[3]}`
 
@@ -590,6 +600,7 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
       play.setAttribute('class', 'markdown-video-play')
 
       el.appendChild(play)
+ 
 
       return
     }


### PR DESCRIPTION
the dtube parser was only processing dtube links that already came with img thumbnail and discarding any raw d.tube links.. Now it is processing both. However, no thumbnail will be shown for raw dtube link.

Let me know if there is any other way to extract dtube thumbnail link...?

fixes #34