### PR TITLE
Nt/parsing extra link data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecency/render-helper",
-  "version": "2.2.38",
+  "version": "2.2.39",
   "description": "Markdown+Html Render helper",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/consts/allowed-attributes.const.ts
+++ b/src/consts/allowed-attributes.const.ts
@@ -16,6 +16,7 @@ export const ALLOWED_ATTRIBUTES: XSSWhiteList = {
     'data-start-time',
     'data-video-href',
     'data-proposal',
+    'data-is-inline',
     'class',
     'title',
     'data-id'

--- a/src/markdown-2-html.spec.ts
+++ b/src/markdown-2-html.spec.ts
@@ -46,7 +46,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: '<a href=\'/esteem/@esteemapp/esteem-monthly-guest-curation-program-4\'>click here</a>'
       }
-      const expected = '<p dir=\"auto\"><a class="markdown-post-link" data-tag="esteem" data-author="esteemapp" data-permlink="esteem-monthly-guest-curation-program-4">click here</a></p>'
+      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-href=\"/esteem/@esteemapp/esteem-monthly-guest-curation-program-4\" data-is-inline=\"true\" data-tag=\"esteem\" data-author=\"esteemapp\" data-permlink=\"esteem-monthly-guest-curation-program-4\">click here</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -58,7 +58,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: '[click here](/esteem/@esteemapp/esteem-monthly-guest-curation-program-4)'
       }
-      const expected = '<p dir=\"auto\"><a class="markdown-post-link" data-tag="esteem" data-author="esteemapp" data-permlink="esteem-monthly-guest-curation-program-4">click here</a></p>'
+      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-href=\"/esteem/@esteemapp/esteem-monthly-guest-curation-program-4\" data-is-inline=\"true\" data-tag=\"esteem\" data-author=\"esteemapp\" data-permlink=\"esteem-monthly-guest-curation-program-4\">click here</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -448,7 +448,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'https://peakd.com/@demo/tests'
       }
-      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-tag=\"post\" data-author=\"demo\" data-permlink=\"tests\">@demo/tests</a></p>'
+      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-href=\"https://peakd.com/@demo/tests\" data-is-inline=\"false\" data-tag=\"post\" data-author=\"demo\" data-permlink=\"tests\">@demo/tests</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -496,7 +496,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'https://peakd.com/tag/@demo/tests and https://steemit.com/test/@demo/post'
       }
-      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-tag=\"tag\" data-author=\"demo\" data-permlink=\"tests\">@demo/tests</a> and <a class=\"markdown-external-link\" data-href=\"https://steemit.com/test/@demo/post\">https://steemit.com/test/@demo/post</a></p>'
+      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-href=\"https://peakd.com/tag/@demo/tests\" data-is-inline=\"false\" data-tag=\"tag\" data-author=\"demo\" data-permlink=\"tests\">@demo/tests</a> and <a class=\"markdown-external-link\" data-href=\"https://steemit.com/test/@demo/post\">https://steemit.com/test/@demo/post</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -664,7 +664,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'this is link https://peakd.com/ccc/jarvie/one-week-roadtrip-to-all-5-utah-national-parks-and-more'
       }
-      const expected = '<p dir=\"auto\">this is link <a class=\"markdown-post-link\" data-tag=\"ccc\" data-author=\"jarvie\" data-permlink=\"one-week-roadtrip-to-all-5-utah-national-parks-and-more\">@jarvie/one-week-roadtrip-to-all-5-utah-national-parks-and-more</a></p>'
+      const expected = '<p dir=\"auto\">this is link <a class=\"markdown-post-link\" data-href=\"https://peakd.com/ccc/jarvie/one-week-roadtrip-to-all-5-utah-national-parks-and-more\" data-is-inline=\"false\" data-tag=\"ccc\" data-author=\"jarvie\" data-permlink=\"one-week-roadtrip-to-all-5-utah-national-parks-and-more\">@jarvie/one-week-roadtrip-to-all-5-utah-national-parks-and-more</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })
@@ -733,7 +733,7 @@ describe('Markdown2Html', () => {
         last_update: '2021-05-10T09:15:49',
         body: '<a href="/@demo/test">test post</a>'
       }
-      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-tag=\"post\" data-author=\"demo\" data-permlink=\"test\">test post</a></p>'
+      const expected = '<p dir=\"auto\"><a class=\"markdown-post-link\" data-href=\"/@demo/test\" data-is-inline=\"true\" data-tag=\"post\" data-author=\"demo\" data-permlink=\"test\">test post</a></p>'
       expect(markdown2Html(input)).toBe(expected)
     })
 
@@ -910,7 +910,7 @@ describe('Markdown2Html', () => {
         last_update: '2019-05-10T09:15:21',
         body: 'direct link https://ecency.com/@ecency/faq?history'
       }
-      const expected = '<p dir=\"auto\">direct link <a class=\"markdown-post-link\" data-tag=\"post\" data-author=\"ecency\" data-permlink=\"faq?history\">@ecency/faq?history</a></p>'
+      const expected = '<p dir=\"auto\">direct link <a class=\"markdown-post-link\" data-href=\"https://ecency.com/@ecency/faq?history\" data-is-inline=\"false\" data-tag=\"post\" data-author=\"ecency\" data-permlink=\"faq?history\">@ecency/faq?history</a></p>'
 
       expect(markdown2Html(input)).toBe(expected)
     })

--- a/src/methods/a.method.ts
+++ b/src/methods/a.method.ts
@@ -109,6 +109,7 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
     if (forApp) {
       el.removeAttribute('href')
 
+      el.setAttribute('data-href', href)
       el.setAttribute('data-is-inline', '' + isInline)
       el.setAttribute('data-tag', tag)
       el.setAttribute('data-author', author)
@@ -186,6 +187,8 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
       }
       if (forApp) {
         el.removeAttribute('href')
+
+        el.setAttribute('data-href', href)
         el.setAttribute('data-is-inline', '' + isInline)
         el.setAttribute('data-tag', tag)
         el.setAttribute('data-author', author)
@@ -256,6 +259,8 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
       }
       if (forApp) {
         el.removeAttribute('href')
+
+        el.setAttribute('data-href', href)
         el.setAttribute('data-is-inline', '' + isInline)
         el.setAttribute('data-tag', tag)
         el.setAttribute('data-author', author)
@@ -356,6 +361,7 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
     if (forApp) {
       el.removeAttribute('href')
 
+      el.setAttribute('data-href', href)
       el.setAttribute('data-is-inline', '' + isInline)
       el.setAttribute('data-tag', tag)
       el.setAttribute('data-author', author)

--- a/src/methods/a.method.ts
+++ b/src/methods/a.method.ts
@@ -101,15 +101,19 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
     const tag = postMatch[2]
     const author = postMatch[3].replace('@', '')
     const permlink = postMatch[4]
+    var isInline = true;
     if (el.textContent === href) {
       el.textContent = `@${author}/${permlink}`
+      isInline = false;
     }
     if (forApp) {
       el.removeAttribute('href')
 
+      el.setAttribute('data-is-inline', '' + isInline)
       el.setAttribute('data-tag', tag)
       el.setAttribute('data-author', author)
       el.setAttribute('data-permlink', permlink)
+
     } else {
       const h = `/${tag}/@${author}/${permlink}`
       el.setAttribute('href', h)
@@ -175,14 +179,18 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
       el.setAttribute('class', 'markdown-post-link')
       const author = tpostMatch[2].replace('@', '')
       const permlink = tpostMatch[3]
+      var isInline = true;
       if (el.textContent === href) {
         el.textContent = `@${author}/${permlink}`
+        isInline = false;
       }
       if (forApp) {
         el.removeAttribute('href')
+        el.setAttribute('data-is-inline', '' + isInline)
         el.setAttribute('data-tag', tag)
         el.setAttribute('data-author', author)
         el.setAttribute('data-permlink', permlink)
+
       } else {
         const h = `/${tag}/@${author}/${permlink}`
         el.setAttribute('href', h)
@@ -241,11 +249,14 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
 
       const author = cpostMatch[1].replace('@', '')
       const permlink = cpostMatch[2]
+      var isInline = true;
       if (el.textContent === href) {
         el.textContent = `@${author}/${permlink}`
+        isInline = false;
       }
       if (forApp) {
         el.removeAttribute('href')
+        el.setAttribute('data-is-inline', '' + isInline)
         el.setAttribute('data-tag', tag)
         el.setAttribute('data-author', author)
         el.setAttribute('data-permlink', permlink)
@@ -337,12 +348,15 @@ export function a(el: HTMLElement, forApp: boolean, webp: boolean): void {
     const tag = 'ccc'
     const author = cccMatch[2].replace('@', '')
     const permlink = cccMatch[3]
+    var isInline = true;
     if (el.textContent === href) {
       el.textContent = `@${author}/${permlink}`
+      isInline = false;
     }
     if (forApp) {
       el.removeAttribute('href')
 
+      el.setAttribute('data-is-inline', '' + isInline)
       el.setAttribute('data-tag', tag)
       el.setAttribute('data-author', author)
       el.setAttribute('data-permlink', permlink)


### PR DESCRIPTION
- added support for `data-is-inline` attribute, attribute is set to `true` if post link is of the pattern `[SOME_CUSTOM_TEXT]{POST_URL}`

- retaining data-href for post-link, this help reference the links_meta cache from json_metadata while rendering link preview.